### PR TITLE
Fix: Set SHELL environment variable for Windows users during installation

### DIFF
--- a/apps/docs/docs/troubleshooting.mdx
+++ b/apps/docs/docs/troubleshooting.mdx
@@ -8,7 +8,19 @@ sidebar_position: 80
 
 # Troubleshooting your BashBuddy installation
 
-TODO
+## "SHELL environment variable is not set" error
+
+BashBuddy requires the SHELL environment variable to be set with the path to your shell executable. This may not be set on Windows.
+
+If you encounter this error:
+
+1. For Windows users:
+   - Open PowerShell
+   - For Windows PowerShell, run: `setx SHELL "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"`
+   - For PowerShell Core, run: `setx SHELL "C:\Program Files\PowerShell\7\pwsh.exe"` (adjust path as needed)
+   - Restart your terminal
+
+The official installer script should set this automatically for Windows users.
 
 ## I still have issues
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -65,6 +65,56 @@ else {
     }
 }
 
+# Set SHELL environment variable if not already set
+if (-not $env:SHELL) {
+    # Determine which PowerShell is being used
+    $isPowerShellCore = $PSVersionTable.PSEdition -eq "Core"
+    
+    if ($isPowerShellCore) {
+        # PowerShell Core (pwsh)
+        try {
+            $shellPath = (Get-Command pwsh).Source
+        } catch {
+            $host.UI.RawUI.ForegroundColor = "Red"
+            Write-Host "PowerShell Core (pwsh) not found in PATH. Please set SHELL environment variable manually."
+            $host.UI.RawUI.ForegroundColor = "White"
+        }
+    } else {
+        # Windows PowerShell (powershell.exe)
+        if (-not $PSHOME) {
+            $host.UI.RawUI.ForegroundColor = "Red"
+            Write-Host "`$PSHOME is not set. Cannot determine Windows PowerShell path. Please set SHELL environment variable manually."
+            $host.UI.RawUI.ForegroundColor = "White"
+        }
+        $shellPath = Join-Path $PSHOME "powershell.exe"
+    }
+    
+    if (setx SHELL $shellPath) {
+        # Update the current session so a restart is not required
+        $env:SHELL = $shellPath
+        
+        # Verify that the environment variable is now available
+        if ($env:SHELL) {
+            $host.UI.RawUI.ForegroundColor = "Green"
+            Write-Host "Successfully set SHELL environment variable to '$shellPath'"
+            $host.UI.RawUI.ForegroundColor = "White"
+        } else {
+            $host.UI.RawUI.ForegroundColor = "Red"
+            Write-Host "SHELL environment variable was not set in the current session."
+            $host.UI.RawUI.ForegroundColor = "White"
+        }
+    } else {
+        $host.UI.RawUI.ForegroundColor = "Red"
+        Write-Host "Failed to set the SHELL environment variable using setx."
+        Write-Host "Please set it manually to '$shellPath'."
+        $host.UI.RawUI.ForegroundColor = "White"
+    }
+} else {
+    $host.UI.RawUI.ForegroundColor = "Yellow"
+    Write-Host "SHELL environment variable is already set to '$env:SHELL'"
+    $host.UI.RawUI.ForegroundColor = "White"
+}
+
 # Install or update @bashbuddy/cli
 $host.UI.RawUI.ForegroundColor = "Cyan"
 Write-Host "Installing/updating @bashbuddy/cli..."


### PR DESCRIPTION
## Problem
BashBuddy CLI requires the SHELL environment variable to run 'ask' commands, which is typically not set in Windows environments. This causes the CLI to fail with "SHELL environment variable is not set" errors for Windows users.

## Solution
This PR:
1. Modifies the PowerShell installer to set the SHELL environment variable to the user's PowerShell executable path
2. Adds troubleshooting documentation for users who need to set it manually

This fix provides a more seamless installation experience for Windows users while also documenting the requirement for better user support.